### PR TITLE
able to contact nodeDocker

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,14 +9,17 @@ import (
 
 func handler(w http.ResponseWriter, r *http.Request) {
     fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
-    fmt.Println("Send reqeust to nodeDocker at localhost:8888")
-    resp, err := http.Get("http://localhost:8888/")
+    fmt.Println("Send reqeust to nodeDocker container at route -> http://nodeDocker:3000")
+    resp, err := http.Get("http://nodedocker:3000/")
     if err != nil {
         fmt.Println("error! error! error!")
+        fmt.Println(err)
+        return 
     }
     defer resp.Body.Close()
     body, err := ioutil.ReadAll(resp.Body)
     fmt.Println("Received: " + string(body))
+    return
 }
 
 func main() {


### PR DESCRIPTION
needed to add http:// to the nodedocker:3000 url
also implemented networking in another "orchestration" repo
returning on error instead of continuing, before it would try to defer resp.body.close()