### PR TITLE
Development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM golang:onbuild
+FROM golang:alpine as builder
+WORKDIR /build
+ADD server.go /build/
+RUN go build server.go
 
-EXPOSE 8080
+FROM alpine
+WORKDIR /app
+COPY --from=builder /build/server /app/
+
+CMD ["./server"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t diakou/go-docker .
+	docker build -t diakou/go-docker:1.2 .
 
 run:
-	docker run --publish 6060:8080 --name testRun --rm diakou/go-docker
+	docker run --publish 6060:8080 --name testRun --rm diakou/go-docker:1.2

--- a/server.go
+++ b/server.go
@@ -8,17 +8,15 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-    fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
-    fmt.Println("Send reqeust to nodeDocker container at route -> http://nodeDocker:3000")
+    // fmt.Println("Send reqeust to nodeDocker container at route -> http://nodeDocker:3000")
     resp, err := http.Get("http://nodedocker:3000/")
     if err != nil {
-        fmt.Println("error! error! error!")
-        fmt.Println(err)
+	fmt.Fprintf(w, "error! error! error!: %s", err)
         return 
     }
     defer resp.Body.Close()
     body, err := ioutil.ReadAll(resp.Body)
-    fmt.Println("Received: " + string(body))
+    fmt.Fprintf(w, "Hi there, I love %s and %s", r.URL.Path[1:], string(body))
     return
 }
 


### PR DESCRIPTION
modified some of server.go printing
changed from singlestage dockerfile to multistage dockerfile
changed from 
original: golang:onbuild (700MB)
current: golang:alpine + build -> binary in alpine (12MB)